### PR TITLE
switched form channel numbers to json

### DIFF
--- a/Collar4/Database2.lsl
+++ b/Collar4/Database2.lsl
@@ -6,7 +6,7 @@
 // All interactions with the external database
 // Timberwoof Lupindo
 // July 2019, February 2020
-// version: 2020-03-08
+// version: 2020-03-08 JSON
 
 // Link-Messages in the 2000 range
 
@@ -14,15 +14,13 @@ integer OPTION_DEBUG = 0;
 key databaseQuery;
 string myQueryStatus;
 
-string name;
+string prisonerName;
 string start_date;
 list assetNumbers; // there's only one
 string assetNumber;
-string crime;
-string class;
-string shocks;
-string rank;
-string specialty;
+string prisonerCrime;
+string prisonerClass;
+
 
 sayDebug(string message)
 {
@@ -41,15 +39,8 @@ sendDatabaseQuery() {
 }
 
 displayCentered(string message) {
-    //sayDebug("displayCentered '"+message+"'");
-    llMessageLinked(LINK_THIS, 2001, message, "");
-}
-
-sendAssetNumbers() {
-    // Send the active asset numbers to Menu
-    string message = llList2Json(JSON_ARRAY, assetNumbers);
-    sayDebug("sendAssetNumbers:"+message);
-    llMessageLinked(LINK_THIS, 1011, message, "");
+    string json = llList2Json(JSON_OBJECT, ["Display",message]);
+    llMessageLinked(LINK_THIS, 0, json, "");
 }
 
 default
@@ -71,34 +62,28 @@ default
             // looks like 
             // Timberwoof Lupindo,0,Piracy; Illegal Transport of Biogenics,284ba63f-378b-4be6-84d9-10db6ae48b8d,P-60361
             list returnedStuff = llParseString2List(message, [","], []);
-            string name = llList2String(returnedStuff, 0);
-            crime = llList2String(returnedStuff, 2);
+            prisonerName = llList2String(returnedStuff, 0);
+            prisonerCrime = llList2String(returnedStuff, 2);
             assetNumber = llList2String(returnedStuff, 4);
             
-            sayDebug("name:"+name);
-            sayDebug("crime:"+crime);
+            sayDebug("name:"+prisonerName);
+            sayDebug("crime:"+prisonerCrime);
             sayDebug("assetNumber:"+assetNumber);
-            
-            llMessageLinked(LINK_THIS, 1800, crime, "");
         }
         else {
             displayCentered("error "+(string)status);
-            llMessageLinked(LINK_THIS, 1800, crime, "Unknown");
             assetNumber = "ERR-" + (string)status;
         }
-        assetNumbers = [assetNumber];
-        sendAssetNumbers();
+        string statusJsonList = llList2Json(JSON_OBJECT, [
+            "assetNumber", assetNumber, 
+            "prisonerCrime", prisonerCrime]);
+        llMessageLinked(LINK_THIS, 0, statusJsonList, "");
     }
     
-    link_message( integer sender_num, integer num, string message, key id ){ 
-        sayDebug("link_message "+(string)num+" "+message);
-        // Someone wants database update
-        if (num == 2002) {
-            sayDebug("link_message "+(string)num+" "+message);
+    link_message( integer sender_num, integer num, string json, key id ){ 
+        sayDebug("link_message "+json);
+        string request = llJsonGetValue(json, ["database"]);
+        if (request != JSON_INVALID)
             sendDatabaseQuery();
-        } else if (num == 1013) {
-            sayDebug("link_message "+(string)num+" "+message);
-            //displayCentered("Function unsupported");
         }
     }
-}

--- a/Collar4/Display.lsl
+++ b/Collar4/Display.lsl
@@ -2,12 +2,12 @@
 // Display script for Black Gazza Collar 4
 // Timberwoof Lupindo
 // June 2019
-// version: 2020-03-07
+// version: 2020-03-08 JSON
 
 // This script handles all display elements of Black Gazza Collar 4.
 // • alphanumeric display
 // • blinky lights
-// • battery display
+// • battery displaydi
 // • floaty text
 
 integer OPTION_DEBUG = 0;
@@ -125,7 +125,7 @@ sayDebug(string message)
 {
     if (OPTION_DEBUG)
     {
-        llWhisper(0,"Display:"+message);
+        llOwnerSay("Display:"+message);
     }
 }
 
@@ -289,12 +289,12 @@ integer uuidToInteger(key uuid)
 }
 
 // get a value from color stored in the blinky and send it to the link
-string blinkyFaceColorToMeaning(integer face, list colors, list names, integer channel){
+string blinkyFaceColorToMeaning(integer face, list colors, list names, string jsonTag){
     list colorList = llGetLinkPrimitiveParams(LinkBlinky, [PRIM_COLOR, face]);
     vector prisonerThreatColor = llList2Vector(colorList,0);
     integer index = llListFindList(colors, [prisonerThreatColor]);
     string stateName = llList2String(names, index); 
-    llMessageLinked(LINK_THIS, channel, stateName, "");
+    llMessageLinked(LINK_THIS, 0, llList2Json(JSON_OBJECT, [jsonTag, stateName]), "");
     return stateName;
 }
 
@@ -344,9 +344,9 @@ default
 
         // Initialize the world
         batteryLevel = "Unknown"; 
-        prisonerMood = blinkyFaceColorToMeaning(FaceAlphanumFrame, moodColors, moodNames, 1100);
-        prisonerClass = blinkyFaceColorToMeaning(FaceBlinky3, classColors, classNames, 1200);
-        prisonerThreat = blinkyFaceColorToMeaning(FaceBlinky4, threatColors, threatLevels, 1500);
+        prisonerMood = blinkyFaceColorToMeaning(FaceAlphanumFrame, moodColors, moodNames, "prisonerMood");
+        prisonerClass = blinkyFaceColorToMeaning(FaceBlinky3, classColors, classNames, "prisonerClass");
+        prisonerThreat = blinkyFaceColorToMeaning(FaceBlinky4, threatColors, threatLevels, "prisonerThreat");
         prisonerCrime = "Unknown";
         displayTitler();
                 
@@ -369,23 +369,24 @@ default
         }
     }
 
-    link_message( integer sender_num, integer num, string message, key id ){ 
-        sayDebug("link_message "+(string)num+" "+message);
+    link_message( integer sender_num, integer num, string json, key id ){ 
+        sayDebug("link_message "+json);
 
         // IC/OOC Mood sets frame color 
-        if (num == 1100) {
-            prisonerMood = message;
-            sayDebug("link_message "+(string)num+" "+prisonerMood+"->prisonerMood");
+        string value = llJsonGetValue(json, ["prisonerMood"]);
+        if (value != JSON_INVALID) {
+            prisonerMood = value;
             integer moodi = llListFindList(moodNames, [prisonerMood]);
             vector moodColor = llList2Vector(moodColors, moodi);
             llSetLinkPrimitiveParamsFast(LinkAlphanumFrame,[PRIM_COLOR, FaceAlphanumFrame, moodColor, 1.0]);
             llSetLinkPrimitiveParamsFast(LinkAlphanumFrame, [PRIM_GLOW, FaceAlphanumFrame, 0.3]);
             displayTitler();
         }
-        
+
         // Prisoner Class sets text color and blinky 3
-        else if (num == 1200) {
-            prisonerClass = message;
+        value = llJsonGetValue(json, ["prisonerClass"]);
+        if (value != JSON_INVALID) {
+            prisonerClass = value;
             sayDebug("link_message "+(string)num+" "+prisonerClass+"->prisonerClass");
             integer classi = llListFindList(classNames, [prisonerClass]);
             prisonerClassColor = llList2Vector(classColors, classi);
@@ -400,12 +401,12 @@ default
             llSetPrimitiveParams([PRIM_SPECULAR, FaceFrame, llList2Key(classSpeculars, classi), <1,1,0>, <0,0,0>, 0, <1,1,1>,255, 75]);
             llSetPrimitiveParams([PRIM_NORMAL, FaceFrame, llList2Key(classBumpmaps, classi), <1,1,0>, <0,0,0>, 0]);
             displayTitler();
-            }
+        }
         
         // Zap Level sets blinky 1
-        else if (num == 1300) {
-            // message contains a json list of settings
-            zapLevelsJSON = message;
+        value = llJsonGetValue(json, ["zapLevels"]);
+        if (value != JSON_INVALID) {
+            zapLevelsJSON = value;
             list zapLevels = llJson2List(zapLevelsJSON);
             sayDebug("link_message "+(string)num+" "+(string)zapLevels+"->message");
             sayDebug("zapLevels list:"+(string)zapLevels);
@@ -418,8 +419,9 @@ default
         }
         
         // Lock level sets blinky 2
-        else if (num == 1400) {
-            prisonerLockLevel = message;
+        value = llJsonGetValue(json, ["prisonerLockLevel"]);
+        if (value != JSON_INVALID) {
+            prisonerLockLevel = value;
             integer locki = llListFindList(lockLevels, [prisonerLockLevel]);
             vector lockcolor = llList2Vector(lockColors, locki);
             sayDebug("lock level message:"+prisonerLockLevel+" locki:"+(string)locki+" lockColors:"+(string)lockcolor);
@@ -427,55 +429,64 @@ default
         }
         
         // Threat level sets blinky 4
-        else if (num == 1500) {
-            prisonerThreat = message;
+        value = llJsonGetValue(json, ["prisonerThreat"]);
+        if (value != JSON_INVALID) {
+            prisonerThreat = value;
             integer threati = llListFindList(threatLevels, [prisonerThreat]);
             vector threatcolor = llList2Vector(threatColors, threati);
-            sayDebug("threat level message:"+message+" threati:"+(string)threati+" threatcolor:"+(string)threatcolor);
+            sayDebug("threat level json:"+json+" threati:"+(string)threati+" threatcolor:"+(string)threatcolor);
             llSetLinkPrimitiveParamsFast(LinkBlinky,[PRIM_COLOR, FaceBlinky4, threatcolor, 1.0]);
             displayTitler();
         }
         
         // Battery Level Report
-        else if (num == 1700) {
-            batteryLevel = message;
-            sayDebug("battery "+message);
-            displayBattery((integer)message);
+        value = llJsonGetValue(json, ["batteryLevel"]);
+        if (value != JSON_INVALID) {
+            batteryLevel = value;
+            sayDebug("batteryLevel "+batteryLevel);
+            displayBattery((integer)batteryLevel);
         }
         
         // Prisoner Crime
-        else if (num == 1800) {
-            prisonerCrime = message;
+        value = llJsonGetValue(json, ["prisonerCrime"]);
+        if (value != JSON_INVALID) {
+            prisonerCrime = value;
             displayTitler();
         }
 
         // set and display asset number
-        else if (num == 2000) {
-            assetNumber = message;
-            if (assetNumber == "") {
-                llOwnerSay("Please select Settings > Asset.");
-            } else {
-                sayDebug("set and display assetNumber \""+assetNumber+"\"");
-                string ownerName = llGetDisplayName(llGetOwner());
-                list namesList = llParseString2List(ownerName, [" "], [""]);
-                string firstName = llList2String(namesList, 0);
-                llSetObjectName(assetNumber+" ("+firstName+")");
-                displayCentered(assetNumber);
-                displayTitler();
-            }
+        value = llJsonGetValue(json, ["assetNumber"]);
+        if (value != JSON_INVALID) {
+            assetNumber = value;
+            sayDebug("set and display assetNumber \""+assetNumber+"\"");
+            string ownerName = llGetDisplayName(llGetOwner());
+            list namesList = llParseString2List(ownerName, [" "], [""]);
+            string firstName = llList2String(namesList, 0);
+            llSetObjectName(assetNumber+" ("+firstName+")");
+            displayCentered(assetNumber);
+            displayTitler();
+        }
+        
+        // display a message
+        value = llJsonGetValue(json, ["Display"]);
+        if (value != JSON_INVALID) {
+            sayDebug("Display "+value);
+            displayCentered(value);
         }
         
         // temporarily display a message
-        else if (num == 2001) {
-            sayDebug("display "+message);
-            displayCentered(message);
+        value = llJsonGetValue(json, ["DisplayTemp"]);
+        if (value != JSON_INVALID) {
+            sayDebug("DisplayTemp "+value);
+            displayCentered(value);
             TIMER_REDISPLAY = 1;
             llSetTimerEvent(3);
         }
         
         // blink battery light for bad words
-        else if (num == 2120) {
-            TIMER_BADWORDS = (integer)message;
+        value = llJsonGetValue(json, ["badWordCount"]);
+        if (value != JSON_INVALID) {
+            TIMER_BADWORDS = (integer)value;
             llSetTimerEvent(1);
             }
     }

--- a/Collar4/Menu.lsl
+++ b/Collar4/Menu.lsl
@@ -2,6 +2,7 @@
 // Menu script for Black Gazza Collar 4
 // Timberwoof Lupindo
 // June 2019
+// version: 2020-03-08 JSON
 
 // Handles all the menus for the collar. 
 // State is kept here and transmitted to interested scripts by link message calls. 
@@ -9,8 +10,8 @@
 // reference: useful unicode characters
 // https://unicode-search.net/unicode-namesearch.pl?term=CIRCLE
 
-string version = "2020-03-08";
-integer OPTION_DEBUG = 0;
+string version = "2020-03-08 JSON";
+integer OPTION_DEBUG = 1;
 
 key sWelcomeGroup="49b2eab0-67e6-4d07-8df1-21d3e03069d0";
 key sMainGroup="ce9356ec-47b1-5690-d759-04d8c8921476";
@@ -40,11 +41,11 @@ integer allowZapMed = 1;
 integer allowZapHigh = 1;
 
 list assetNumbers;
-string ICOOCMood = "OOC";
+string prisonerMood = "OOC";
 string prisonerClass = "white";
 list prisonerClasses = ["white", "pink", "red", "orange", "green", "blue", "black"];
 list prisonerClassesLong = ["Unassigned Transfer", "Sexual Deviant", "Mechanic", "General Population", "Medical Experiment", "Violent or Hopeless", "Mental"];
-string theLocklevel = "Off";
+string prisonerLockLevel = "Off";
 list LockLevels = ["Off", "Light", "Medium", "Heavy", "Hardcore"];
 integer rlvPresent = 0;
 integer renamerActive = 0;
@@ -52,7 +53,7 @@ integer gagActive = 0;
 
 string prisonerCrime = "Unknown";
 string assetNumber = "Unknown";
-string threatLevel = "Moderate";
+string prisonerThreat = "Moderate";
 string batteryLevel = "Unknown";
 integer badWordsActive = 0;
 
@@ -78,11 +79,31 @@ sayDebug(string message)
     }
 }
 
-tempDisplay(string message) 
-// send the message to the alphanumeric Display
-{
-    llMessageLinked(LINK_THIS, 2001, message, "");
-}
+sendJSON(string jsonKey, string value, key avatarKey){
+    llMessageLinked(LINK_THIS, 0, llList2Json(JSON_OBJECT, [jsonKey, value]), avatarKey);
+    }
+    
+sendJSONinteger(string jsonKey, integer value, key avatarKey){
+    llMessageLinked(LINK_THIS, 0, llList2Json(JSON_OBJECT, [jsonKey, (string)value]), avatarKey);
+    }
+    
+string getJSONstring(string jsonValue, string jsonKey, string valueNow){
+    string result = valueNow;
+    string value = llJsonGetValue(jsonValue, [jsonKey]);
+    if (value != JSON_INVALID) {
+        result = value;
+        }
+    return result;
+    }
+    
+integer getJSONinteger(string jsonValue, string jsonKey, integer valueNow){
+    integer result = valueNow;
+    string value = llJsonGetValue(jsonValue, [jsonKey]);
+    if (value != JSON_INVALID) {
+        result = (integer)value;
+        }
+    return result;
+    }
 
 setUpMenu(string identifier, key avatarKey, string message, list buttons)
 // wrapper to do all the calls that make a simple menu dialog.
@@ -93,7 +114,7 @@ setUpMenu(string identifier, key avatarKey, string message, list buttons)
         buttons = buttons + ["Main"];
     }
     
-    tempDisplay("menu access");
+    sendJSON("DisplayTemp", "menu access", avatarKey);
     menuIdentifier = identifier;
     menuAgentKey = avatarKey; // remember who clicked
     string completeMessage = assetNumber + " Collar: " + message;
@@ -154,7 +175,7 @@ mainMenu(key avatarKey) {
     string message = "Main";
 
     if (assetNumber == "Unknown") {
-        llMessageLinked(LINK_THIS, 2002, "", avatarKey);
+        sendJSON("database", "getupdate", avatarKey);
     }
     
     if (menuAgentKey != "" & menuAgentKey != avatarKey) {
@@ -169,17 +190,17 @@ mainMenu(key avatarKey) {
     integer doRelease = 0;
     
     // enable things based on state
-    if (!llSameGroup(avatarKey) && (ICOOCMood != "OOC") && (ICOOCMood != "DnD")) {
+    if (!llSameGroup(avatarKey) && (prisonerMood != "OOC") && (prisonerMood != "DnD")) {
         doZap = 1;
     }
     
-    if (avatarKey == llGetOwner() && theLocklevel != "Hardcore" && theLocklevel != "Off") {
+    if (avatarKey == llGetOwner() && prisonerLockLevel != "Hardcore" && prisonerLockLevel != "Off") {
         doSafeword = 1;
     } else {
         message = message + "\nSafeword is only availavle to the Prisoner in RLV levels Medium and Heavy.";
     }
     
-    if (theLocklevel != "Off" && !llSameGroup(avatarKey)) {
+    if (prisonerLockLevel != "Off" && !llSameGroup(avatarKey)) {
         doRelease = 1;
     } else {
         message = message + "\nRelease is only availavle to a Guard while prisoner is in RLV Hardcore mode.";
@@ -207,18 +228,16 @@ doMainMenu(key avatarKey, string message) {
             zapMenu(avatarKey);
         }
         else if (message == "Leash"){
-            llMessageLinked(LINK_THIS, 1901, "Leash", avatarKey);
+            sendJSON("Leash", "Leash", avatarKey);
         }
         else if (message == "Speech"){
             speechMenu(avatarKey);
         }
         else if (message == "Safeword"){
-            llMessageLinked(LINK_THIS, 1401, "Safeword", avatarKey);
+            sendJSON("RLV", "Safeword", avatarKey);
         }
         else if (message == "Release"){
-            theLocklevel = "Off";
-            renamerActive = 0;
-            llMessageLinked(LINK_THIS, 1401, "Off", avatarKey);
+            sendJSON("RLV", "Off", avatarKey);
         }
     }
 
@@ -267,7 +286,7 @@ infoGive(key avatarKey){
         message = message + 
         "Crime: " + prisonerCrime + "\n" +
         "Class: "+class2Description(prisonerClass)+"\n" +
-        "Threat: " + threatLevel + "\n" +
+        "Threat: " + prisonerThreat + "\n" +
         "Zap Levels: " + ZapLevels + "\n"; 
     } else {
         string restricted = "RESTRICTED INFO";
@@ -280,9 +299,9 @@ infoGive(key avatarKey){
     message = message + "Battery Level: " + batteryGraph(batteryLevel)+"\n";
     message = message + "------------------\nOOC Information:\n";
     message = message + "Version: " + version + "\n";
-    message = message + "Mood: " + ICOOCMood + "\n";
+    message = message + "Mood: " + prisonerMood + "\n";
     if (rlvPresent) {
-        message = message + "RLV Active: " + theLocklevel + "\n";
+        message = message + "RLV Active: " + prisonerLockLevel + "\n";
     } else {
         message = message + "RLV not detected.\n";
     }
@@ -319,7 +338,7 @@ hackMenu(key avatarKey)
 speechMenu(key avatarKey)
 {
     integer itsMe = avatarKey == llGetOwner();
-    integer locked = theLocklevel != "Off";
+    integer locked = prisonerLockLevel != "Off";
     
     string message = "";
     list buttons = [];
@@ -341,7 +360,7 @@ speechMenu(key avatarKey)
         message = message + "\nRenamer, Gag, and BadWords only work when the collar is locked.";
     }
     if (itsMe) {
-        if (ICOOCMood == "OOC") {
+        if (prisonerMood == "OOC") {
             doWordList = 1;
         } else {
             message = message + "\nYou can only change your word list while OOC.";
@@ -366,19 +385,19 @@ doSpeechMenu(key avatarKey, string message, string messageButtonsTrimmed)
 {
     if (messageButtonsTrimmed == "Renamer") {
         renamerActive = !renamerActive;
-        llMessageLinked(LINK_THIS, 2101+renamerActive, "", avatarKey); 
+        sendJSONinteger("setRenamer", renamerActive, avatarKey);
         sayDebug("doSpeechMenu renamerActive:"+(string)renamerActive);
         speechMenu(avatarKey);
     } else if (message == "WordList") {
-        llMessageLinked(LINK_THIS, 2110, "", avatarKey);
+        sendJSON("RLV","WordList", avatarKey);
     } else if (messageButtonsTrimmed == "BadWords") {
         badWordsActive = !badWordsActive;
-        llMessageLinked(LINK_THIS, 2111+badWordsActive, "", avatarKey);
+        sendJSONinteger("setBadWordsActive", badWordsActive, avatarKey);
         sayDebug("doSpeechMenu badWordsActive:"+(string)badWordsActive);
         speechMenu(avatarKey);
     } else if (messageButtonsTrimmed == "Gag") {
         gagActive = !gagActive;
-        llMessageLinked(LINK_THIS, 2131+gagActive, "", avatarKey);
+        sendJSONinteger("setGag", gagActive, avatarKey);
         sayDebug("doSpeechMenu gagActive:"+(string)gagActive);
         speechMenu(avatarKey);
     } else {
@@ -419,7 +438,7 @@ settingsMenu(key avatarKey) {
         setLock = 1;
         
         // Some things you can only change OOC
-        if ((ICOOCMood == "OOC") || (ICOOCMood == "DnD")) {
+        if ((prisonerMood == "OOC") || (prisonerMood == "DnD")) {
             sayDebug("settingsMenu: ooc");
             // IC or DnD you change everything
             setClass = 1;
@@ -440,7 +459,7 @@ settingsMenu(key avatarKey) {
         setThreat = 1;
         
         // some things guard can change only OOC
-        if (ICOOCMood == "OOC") {
+        if (prisonerMood == "OOC") {
             sayDebug("settingsMenu: ooc");
             // OOC, guards can change some things
             // DnD means Do Not Disturb
@@ -452,7 +471,7 @@ settingsMenu(key avatarKey) {
     }
     
     // Lock level changes some privileges
-    if ((theLocklevel == "Hardcore" || theLocklevel == "Heavy")) {
+    if ((prisonerLockLevel == "Hardcore" || prisonerLockLevel == "Heavy")) {
         if (avatarKey == llGetOwner()) {
             sayDebug("settingsMenu: heavy-owner");
             setZaps = 0;
@@ -489,7 +508,7 @@ doSettingsMenu(key avatarKey, string message, string messageButtonsTrimmed) {
             } else {
                 // get RLV to check RLV again 
                 llOwnerSay("RLV was off nor not detected. Attempting to register with RLV.");
-                llMessageLinked(LINK_THIS, 1410, "Register RLV", avatarKey);
+                sendJSON("RLV", "Register", avatarKey);
             }
         }
         else if (message == "Class"){
@@ -548,9 +567,8 @@ doSetZapLevels(key avatarKey, string message)
         if (allowZapLow + allowZapMed + allowZapHigh == 0) {
             allowZapHigh = 1;
         }
-        // Send the zap status message
         string zapJsonList = llList2Json(JSON_ARRAY, [allowZapLow, allowZapMed, allowZapHigh]);
-        llMessageLinked(LINK_THIS, 1300, zapJsonList, avatarKey);
+        sendJSON("zapLevels", zapJsonList, avatarKey);
     }
 }
 
@@ -581,13 +599,13 @@ moodMenu(key avatarKey)
     {
         string message = "Set your Mood";
         list buttons = [];
-        buttons = buttons + menuRadioButton("OOC", ICOOCMood);
-        buttons = buttons + menuRadioButton("Submissive", ICOOCMood);
-        buttons = buttons + menuRadioButton("Versatile", ICOOCMood);
-        buttons = buttons + menuRadioButton("Dominant", ICOOCMood);
-        buttons = buttons + menuRadioButton("Nonsexual", ICOOCMood);
-        buttons = buttons + menuRadioButton("Story", ICOOCMood);
-        buttons = buttons + menuRadioButton("DnD", ICOOCMood);
+        buttons = buttons + menuRadioButton("OOC", prisonerMood);
+        buttons = buttons + menuRadioButton("Submissive", prisonerMood);
+        buttons = buttons + menuRadioButton("Versatile", prisonerMood);
+        buttons = buttons + menuRadioButton("Dominant", prisonerMood);
+        buttons = buttons + menuRadioButton("Nonsexual", prisonerMood);
+        buttons = buttons + menuRadioButton("Story", prisonerMood);
+        buttons = buttons + menuRadioButton("DnD", prisonerMood);
         setUpMenu("Mood", avatarKey, message, buttons);
     }
     else
@@ -605,8 +623,8 @@ lockMenu(key avatarKey)
             
         // LockLevels: 0=Off 1=Light 2=Medium 3=Heavy 4=Hardcore
         // convert our locklevel to an integer
-        sayDebug("lockMenu theLocklevel:"+theLocklevel);
-        integer iLockLevel = llListFindList(LockLevels, [theLocklevel]);
+        sayDebug("lockMenu prisonerLockLevel:"+prisonerLockLevel);
+        integer iLockLevel = llListFindList(LockLevels, [prisonerLockLevel]);
         sayDebug("lockMenu iLocklevel:"+(string)iLockLevel);
         // make a list of what lock levels are available from each lock level
         list lockListOff = [0, 1, 2, 3];
@@ -626,7 +644,7 @@ lockMenu(key avatarKey)
             integer lockindex =  llList2Integer(lockListMenu, listsIndex);
             if (lockindex != -1) {
                 string lockButton = llList2String(LockLevels, lockindex);
-                buttons = buttons + menuRadioButton(lockButton, theLocklevel); 
+                buttons = buttons + menuRadioButton(lockButton, prisonerLockLevel); 
                 allTheButtons = allTheButtons + lockButton;
             }
         }
@@ -667,10 +685,10 @@ confirmHardcore(key avatarKey) {
 threatMenu(key avatarKey) {
     string message = "Threat";
     list buttons = [];
-    buttons = buttons + menuRadioButton("None", threatLevel);
-    buttons = buttons + menuRadioButton("Moderate", threatLevel);
-    buttons = buttons + menuRadioButton("Dangerous", threatLevel);
-    buttons = buttons + menuRadioButton("Extreme", threatLevel);
+    buttons = buttons + menuRadioButton("None", prisonerThreat);
+    buttons = buttons + menuRadioButton("Moderate", prisonerThreat);
+    buttons = buttons + menuRadioButton("Dangerous", prisonerThreat);
+    buttons = buttons + menuRadioButton("Extreme", prisonerThreat);
     setUpMenu("Threat", avatarKey, message, buttons);
 }
 
@@ -691,12 +709,10 @@ default
     {
         sayDebug("state_entry");
         menuAgentKey = "";
-        theLocklevel = "Off"; 
+        prisonerLockLevel = "Off"; 
         renamerActive = 0;       
         touchTones = [touchTone0, touchTone1, touchTone2, touchTone3, touchTone4, 
             touchTone5, touchTone6, touchTone7, touchTone8, touchTone9];
-        llMessageLinked(LINK_THIS, 1402, "", ""); // ask for RLV update
-        llMessageLinked(LINK_THIS, 2002, "", ""); // ask for database update
         doSetZapLevels(llGetOwner(),""); // initialize
     }
 
@@ -716,9 +732,9 @@ default
                 menuCheckbox("High", allowZapHigh);
                 llInstantMessage(avatarKey, assetNumber+" Zap: "+ZapLevels);
                 }
-            else if (touchedFace == FaceBlinky2) {llInstantMessage(avatarKey, assetNumber+" Lock Level: "+theLocklevel);}
+            else if (touchedFace == FaceBlinky2) {llInstantMessage(avatarKey, assetNumber+" Lock Level: "+prisonerLockLevel);}
             else if (touchedFace == FaceBlinky3) {llInstantMessage(avatarKey, assetNumber+" Class: "+prisonerClass + ": "+class2Description(prisonerClass));}
-            else if (touchedFace == FaceBlinky4) {llInstantMessage(avatarKey, assetNumber+" Threat: "+threatLevel);}
+            else if (touchedFace == FaceBlinky4) {llInstantMessage(avatarKey, assetNumber+" Threat: "+prisonerThreat);}
             else if (touchedFace == batteryIconFace) llInstantMessage(avatarKey, assetNumber+" Battery level: "+batteryLevel+"%");
         } else if (touchedLink == batteryCoverLink) {
             if (touchedFace == batteryCoverFace) llInstantMessage(avatarKey, assetNumber+" Battery level: "+batteryLevel+"%");
@@ -734,9 +750,9 @@ default
         sayDebug("listen menuIdentifier: "+menuIdentifier);
         tone(channel);
         if (llGetSubString(message,1,1) == " ") {
-            tempDisplay(messageButtonsTrimmed);
+            sendJSON("DisplayTemp", messageButtonsTrimmed, avatarKey);
         } else {
-            tempDisplay(message);
+            sendJSON("DisplayTemp", message, avatarKey);
         }    
 
         // reset the menu setup
@@ -774,8 +790,7 @@ default
             if (message != "OK") {
                 assetNumber = message;
                 // The wearer chose this asset number so transmit it and display it
-                llMessageLinked(LINK_THIS, 1013, assetNumber, avatarKey);
-                llMessageLinked(LINK_THIS, 2000, assetNumber, avatarKey);
+                sendJSON("assetNumber", assetNumber, avatarKey);
                 settingsMenu(avatarKey);
             }
         }
@@ -784,22 +799,22 @@ default
         else if (menuIdentifier == "Class") {
             sayDebug("listen: Class:"+messageButtonsTrimmed);
             prisonerClass = messageButtonsTrimmed;
-            llMessageLinked(LINK_THIS, 1200, prisonerClass, avatarKey);
+            sendJSON("prisonerClass", prisonerClass, avatarKey);
             settingsMenu(avatarKey);
         }
         
         // Mood
         else if (menuIdentifier == "Mood") {
             sayDebug("listen: Mood:"+messageButtonsTrimmed);
-            ICOOCMood = messageButtonsTrimmed;
-            llMessageLinked(LINK_THIS, 1100, ICOOCMood, avatarKey);
+            prisonerMood = messageButtonsTrimmed;
+            sendJSON("prisonerMood", prisonerMood, avatarKey);
             settingsMenu(avatarKey);
         }
         
         // Zap the inmate
         else if (menuIdentifier == "Zap") {
             sayDebug("listen: Zap:"+message);
-            llMessageLinked(LINK_THIS, 1301, message, avatarKey);
+            sendJSON("RLV", "zapPrisoner", avatarKey);
         }
 
         // Set Zap Level
@@ -819,12 +834,12 @@ default
             if (message == "○ Hardcore") {
                 confirmHardcore(avatarKey);
             } else if (message == "⨷ Hardcore") {
-                sayDebug("listen set theLocklevel:\""+theLocklevel+"\"");
-                llMessageLinked(LINK_THIS, 1401, "Hardcore", avatarKey);
+                sayDebug("listen set prisonerLockLevel:\""+prisonerLockLevel+"\"");
+                sendJSON("RLV", "Hardcore", avatarKey);
             } else {
-                sayDebug("listen set theLocklevel:\""+theLocklevel+"\"");
-                llMessageLinked(LINK_THIS, 1401, messageButtonsTrimmed, avatarKey);
-                if (theLocklevel == "Off") {
+                sayDebug("listen set prisonerLockLevel:\""+prisonerLockLevel+"\"");
+                sendJSON("RLV", messageButtonsTrimmed, avatarKey);
+                if (prisonerLockLevel == "Off") {
                     renamerActive = 0;
                 }
                 settingsMenu(avatarKey);
@@ -833,9 +848,9 @@ default
 
         // Threat Level
         else if (menuIdentifier == "Threat") {
-            sayDebug("listen: threatLevel:"+messageButtonsTrimmed);
-            threatLevel = messageButtonsTrimmed;
-            llMessageLinked(LINK_THIS, 1500, threatLevel, avatarKey);
+            sayDebug("listen: prisonerThreat:"+messageButtonsTrimmed);
+            prisonerThreat = messageButtonsTrimmed;
+            sendJSON("prisonerThreat", prisonerThreat, avatarKey);
             settingsMenu(avatarKey);
         }
         
@@ -854,44 +869,18 @@ default
         }
     }
     
-    link_message(integer sender_num, integer num, string message, key avatarKey){ 
+    link_message(integer sender_num, integer num, string json, key avatarKey){ 
     // We listen in on link status messages and pick the ones we're interested in
-        sayDebug("Menu link_message "+(string)num+" "+message);
-        if (num == 1011) {
-            assetNumbers = llJson2List(message);
-            assetNumber = llList2String(assetNumbers, 0);
-            llMessageLinked(LINK_THIS, 1013, assetNumber, avatarKey);
-            llMessageLinked(LINK_THIS, 2000, assetNumber, avatarKey);
-        } else if (num == 1100) {
-            ICOOCMood = message;
-        } else if (num == 1200) {
-            prisonerClass = message;
-        } else if (num == 1400) {
-            // RLV level: Off, Light, Medium, heavy, Hardcore
-            if (rlvPresent == 1) {
-                theLocklevel = message;
-            } else {
-                theLocklevel = "Off";
-                renamerActive = 0;
-            }
-            sayDebug("link_message set theLocklevel:"+theLocklevel);
-        } else if (num == 1403) {
-            // RLV Presence
-            if (message == "NoRLV") {
-                rlvPresent = 0;
-                renamerActive = 0;
-                theLocklevel = "Off";
-            } else if (message == "YesRLV") {
-                rlvPresent = 1;
-            }
-            sayDebug("link_message set rlvPresent:"+(string)rlvPresent);
-        } else if (num == 1700) {
-            batteryLevel = message;
-        } else if (num == 1800) {
-            prisonerCrime = message;
-        } else if (num == 2000) {
-            assetNumber = message;
-        }
+        sayDebug("link_message json "+json);
+        assetNumber = getJSONstring(json, "assetNumber", assetNumber);
+        prisonerCrime = getJSONstring(json, "prisonerCrime", prisonerCrime);
+        prisonerClass = getJSONstring(json, "prisonerClass", prisonerClass);
+        prisonerThreat = getJSONstring(json, "prisonerThreat", prisonerThreat);
+        prisonerMood = getJSONstring(json, "prisonerMood", prisonerMood);
+        rlvPresent = getJSONinteger(json, "rlvPresent", rlvPresent);
+        prisonerLockLevel = getJSONstring(json, "prisonerLockLevel", prisonerLockLevel);
+        renamerActive = getJSONinteger(json, "renamerActive", renamerActive);
+        batteryLevel = getJSONstring(json, "batteryLevel", batteryLevel);
     }
     
     timer() 


### PR DESCRIPTION
Battery
added getJSONstring to retrieve values form json blob
added updateVlaue to tell if a tag was in a json blob
cleaned up link_message with json

Database
standardized entity keys
new sendAssetNumbers 
sends database info via json
no more responding to database update

Display
fixed translation of blinky face colors to meanings for new types and keys
receives json key-value pairs instead of channel-value pairs

Menu
standardized entity keys
added common json encoders and decoders
No more asking database for updates
message_linked calls are now sendJSON calls

RLV
standardized entity keys
standard JSON encoders and decoders